### PR TITLE
Martin | yUfIbsBe | contact normal generation is now consistent. Added unit tests for the different types of collision.

### DIFF
--- a/src/Systems/Physics/CollisionDetector.hpp
+++ b/src/Systems/Physics/CollisionDetector.hpp
@@ -8,6 +8,19 @@
 #include "Collider.hpp"
 #include "AABB.hpp"
 
+class SATData
+{
+    public:
+        int         indexFace;
+        int         indexEdgeA;
+        int         indexEdgeB;
+        bool        indexFaceA;
+        bool        isFaceCollision;
+        float       minPenDepth;
+        float       minEdgeDistance;
+        glm::vec3   collisionAxis;
+};
+
 /**
 Collision detector contains all the logic that checks if two colliders are intersecting.
  */
@@ -17,8 +30,26 @@ class CollisionDetector
         CollisionDetector();
 
         std::shared_ptr<Collision> CheckCollision(std::shared_ptr<Collider> first, std::shared_ptr<Collider> second);
-        std::shared_ptr<Collision> AABBToAABB(std::shared_ptr<AABB> first, std::shared_ptr<AABB> second);
         std::shared_ptr<Collision> Collide(std::shared_ptr<Collider> first, std::shared_ptr<Collider> second);
+
+        bool CheckFaces(SATData& data, 
+                        const std::vector<glm::vec3>& pointsA, 
+                        const std::vector<glm::vec3>& pointsB,
+                        const std::vector<std::pair<glm::vec3, float>>& faces,
+                        const std::vector<glm::vec3>& pointsOnFaces,
+                        std::shared_ptr<Collider> first,
+                        std::shared_ptr<Collider> second,
+                        bool isFaceA);
+        bool CheckEdges(SATData& data,
+                        const std::vector<glm::vec3>& pointsA,
+                        const std::vector<glm::vec3>& pointsB,
+                        const std::vector<std::pair<glm::vec3, glm::vec3>>& edgesA,
+                        const std::vector<std::pair<glm::vec3, glm::vec3>>& edgesB);
+
+        std::vector<glm::vec3> GetCollisionPoints(SATData& data, 
+                                                  const std::vector<glm::vec3>& points,
+                                                  const std::vector<std::pair<glm::vec3, float>>& faces,
+                                                  const std::vector<glm::vec3>& pointsOnFaces);
 
         // Helpers
         /** 

--- a/test/CollisionDetectorTest.cpp
+++ b/test/CollisionDetectorTest.cpp
@@ -1,0 +1,101 @@
+#include "catch.hpp"
+#include <memory>
+#include <iostream>
+#include "../src/Systems/Physics/Plane.hpp"
+#include "../src/Systems/Physics/AABB.hpp"
+#include "../src/Systems/Physics/CollisionDetector.hpp"
+
+TEST_CASE("CollisionDetector Test")
+{
+	CollisionDetector detector = CollisionDetector();
+	// setup
+	// to test
+	// 1. contact normal direction
+	// 2. different angled collisions and if they produce the right results.
+
+	// types of collisions
+	// BOX Face to Plane face - box1 and plane1
+	// Box Face to Plane edge - box1 and plane2
+	// box edge to plane edge - box1 and plane3
+	// Box face to box face - box1 and box2
+
+	std::vector<glm::vec3> pointsPlane1;
+	pointsPlane1.push_back(glm::vec3(-1.f, 0.f, 0.05f));
+	pointsPlane1.push_back(glm::vec3(4.f, 0.f, 0.05f));
+	pointsPlane1.push_back(glm::vec3(-1.f, 4.f, 0.05f));
+	pointsPlane1.push_back(glm::vec3(4.f, 4.f, 0.05f));
+	std::shared_ptr<Plane> plane1 = std::make_shared<Plane>(Plane(1, glm::vec3(1.5f, 2.f, 0.f),
+																	ColliderType::PLANE,
+																	DynamicType::Static,
+																	pointsPlane1));
+
+	std::vector<glm::vec3> pointsPlane2;
+	pointsPlane2.push_back(glm::vec3(1.8f, 1.72f, 2.82f));
+	pointsPlane2.push_back(glm::vec3(1.8f, 1.72f, 1.82f));
+	pointsPlane2.push_back(glm::vec3(0.8f, 1.f, 2.82f));
+	pointsPlane2.push_back(glm::vec3(0.8f, 1.f, 1.82f));
+	std::shared_ptr<Plane> plane2 = std::make_shared<Plane>(Plane(444, glm::vec3(1.3f, 1.3f, 2.32f),
+																	ColliderType::PLANE,
+																	DynamicType::Static,
+																	pointsPlane2));
+
+	std::vector<glm::vec3> pointsPlane3;
+	pointsPlane3.push_back(glm::vec3(3.f, 1.f, 1.f));
+	pointsPlane3.push_back(glm::vec3(0.9f, -1.f, 1.f));
+	pointsPlane3.push_back(glm::vec3(2.f, -2.f, 1.f));
+	pointsPlane3.push_back(glm::vec3(4.f, 0.f, 1.f));
+	std::shared_ptr<Plane> plane3 = std::make_shared<Plane>(Plane(33, glm::vec3(2.5f, -0.5f, 1.f),
+																	ColliderType::PLANE,
+																	DynamicType::Static,
+																	pointsPlane3));	
+
+	std::shared_ptr<AABB> box1 = std::make_shared<AABB>(AABB(4, glm::vec3(1.f, 1.f, 1.f), 
+																ColliderType::BOX, 
+																DynamicType::Dynamic,
+																glm::vec3(1.f, 1.f, 1.f)));
+
+	std::shared_ptr<AABB> box2 = std::make_shared<AABB>(AABB(666, glm::vec3(-0.9f, 1.1f, 1.1f),
+																ColliderType::BOX,
+																DynamicType::Dynamic,
+																glm::vec3(1.f, 1.f, 1.f)));
+
+	SECTION("Box Faces - Plane Face")
+	{
+		std::shared_ptr<Collision> collision1 = detector.CheckCollision(box1, plane1);
+		REQUIRE(collision1 != nullptr);
+		REQUIRE(collision1->contacts.size() == 4);
+		float dotResult = glm::dot(collision1->contacts[0].contactNormal,glm::vec3(0.f, 0.f, 1.f)) - 1.f;
+		REQUIRE( dotResult < 0.0000005f);
+		REQUIRE( dotResult >= 0.f);
+	}
+	SECTION("Box Face - Plane edge")
+	{
+		std::shared_ptr<Collision> collision2 = detector.CheckCollision(box1, plane2);
+		REQUIRE(collision2 != nullptr);
+		REQUIRE(collision2->contacts.size() == 2);
+		float dotResult = glm::dot(collision2->contacts[0].contactNormal,glm::vec3(0.f, 0.f, 1.f)) + 1.f;
+		REQUIRE( dotResult < 0.0000005f);
+		REQUIRE( dotResult >= 0.f);
+	}
+	SECTION("Box Edge - Plane edge")
+	{
+		std::shared_ptr<Collision> collision2 = detector.CheckCollision(box1, plane3);
+		REQUIRE(collision2 != nullptr);
+		REQUIRE(collision2->contacts.size() == 1);
+		glm::vec3 edgeA = glm::vec3(3.f, 1.f, 1.f) - glm::vec3(0.9f, -1.f, 1.f);
+		glm::vec3 edgeB = glm::vec3(2.f, 0.f, 2.f) - glm::vec3(2.f, 0.f, 0.f);
+		glm::vec3 expectedNormal = glm::normalize(glm::cross(edgeA, edgeB));
+		float dotResult = glm::dot(collision2->contacts[0].contactNormal,expectedNormal) + 1.f;
+		REQUIRE( dotResult < 0.0000005f);
+		REQUIRE( dotResult >= 0.f);
+	}
+	SECTION("Box Face - Plane Face")
+	{
+		std::shared_ptr<Collision> collision2 = detector.CheckCollision(box1, box2);
+		REQUIRE(collision2 != nullptr);
+		REQUIRE(collision2->contacts.size() == 4);
+		float dotResult = glm::dot(collision2->contacts[0].contactNormal, glm::vec3(1.f, 0.f, 0.f)) - 1.f;
+		REQUIRE( dotResult < 0.0000005f);
+		REQUIRE( dotResult >= 0.f);
+	}
+}

--- a/test/GridTest.cpp
+++ b/test/GridTest.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Grid Test")
 	glm::vec3 axisRadii2 = glm::vec3(2.5f,2.5f,2.5f);
 	std::shared_ptr<AABB> box2 = std::make_shared<AABB>(AABB(4, box_center2, ColliderType::BOX, DynamicType::Dynamic, axisRadii2));
 
-	glm::vec3 box_center3 = glm::vec3(17.5f, 2.5f, 6.5f);
+	glm::vec3 box_center3 = glm::vec3(17.5f, 3.5f, 6.5f);
 	std::shared_ptr<AABB> box3 = std::make_shared<AABB>(AABB(5, box_center3, ColliderType::BOX, DynamicType::Dynamic, axisRadii2));
 
 	grid.Insert(plane1);
@@ -126,7 +126,7 @@ TEST_CASE("Grid Test")
 		REQUIRE(collision2->second == 5);
 		REQUIRE(collision2->firstCollider->entityID == 4);
 		REQUIRE(collision2->secondCollider->entityID == 5);
-		REQUIRE(collision2->contacts.size() == 4);
+		REQUIRE(collision2->contacts.size() == 2);
 		for (int i = 0; i < collision2->contacts.size(); i++)
 		{
 			REQUIRE(collision2->contacts[i].penetration - 1.0f < 0.00005f);

--- a/test/PhysicsSystemTest.cpp
+++ b/test/PhysicsSystemTest.cpp
@@ -60,15 +60,6 @@ TEST_CASE("PhysicsSystem Test")
 	std::vector<std::shared_ptr<Collider>> colliders{plane1, box1};
 	physicsSystem.Insert(colliders);
 
-	std::cout << "position before" << std::endl;
-	std::cout << component2->position.x << std::endl;
-	std::cout << component2->position.y << std::endl;
-	std::cout << component2->position.z << std::endl;
-	std::cout << "velocity before" << std::endl;
-	std::cout << component2->velocity.x << std::endl;
-	std::cout << component2->velocity.y << std::endl;
-	std::cout << component2->velocity.z << std::endl;
-
 	std::vector<std::shared_ptr<Entity>> entities{entity1, entity2};
 	std::vector<Message> messages;
 	std::vector<Message> globalQueue;


### PR DESCRIPTION
## Problem

Different executions  of **CollisionDetector::Collide** on the same set of colliders could produce different contact normals (same axis, different direction). This in turn could affect the the PhysicsSystem Update.

----------------------------------------------------------------------------------------------------------------------
## Solution

### 1. Contact normal is a face normal

We need to make sure that when we create the collision object the **owner** of the normal is placed as the **second** collider or we switch negate the normal. This is because the **PhysicsSystem** does +impulse on the first and -impulse on the second.

### 2. Contact Normal is an edge normal

If the contact normal points in the same direction as the vector from first to second (second.center - first.center) then we need to switch first and second in the Collision object.

## Card

https://trello.com/c/yUfIbsBe/2-contact-normal-returned-from-the-sat-algorithm-is-not-consistent