### PR TITLE
qUPxGwkX | moving from shared_ptr to unique_ptr and raw pointers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,37 @@
 os: linux
 sudo: true
 jobs:
-  include:
-    - stage: Build and Test
-      script: make && make test && ./out/test
-    - stage: Code Coverage
-      script: 
-        - make gcov && ./out/gcov_exe
-        - chmod +x ./scripts/get_code_coverage_reports.sh
-        - cd ./out
-        - ../scripts/get_code_coverage_reports.sh
-        - cd ../
-        - codecov
+    include:
+        - stage: Build and Test
+            script: make && make test && ./out/test
+        - stage: Code Coverage
+            script: 
+                - make gcov && ./out/gcov_exe
+                - chmod +x ./scripts/get_code_coverage_reports.sh
+                - cd ./out
+                - ../scripts/get_code_coverage_reports.sh
+                - cd ../
+                - codecov
     - stage: Documentation Generation
-      script:
-        - chmod +x ./scripts/run_doxygen.sh
-        - mkdir docs
-        - ./scripts/run_doxygen.sh
-      deploy:
-        provider: pages
-        skip_cleanup: true
-        github_token: $GH_TOKEN
-        local_dir: ./docs/html
-compiler: g++-8
+          script:
+                - chmod +x ./scripts/run_doxygen.sh
+                - mkdir docs
+                - ./scripts/run_doxygen.sh
+          deploy:
+                provider: pages
+                skip_cleanup: true
+                github_token: $GH_TOKEN
+                local_dir: ./docs/html
+compiler: gcc-8
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+        packages:
+            - gcc-8
 language: cpp
 notifications: never
 before_install:
-  - sudo pip install codecov
-  - mkdir out
-  - sudo apt-get install -y gcc-8 libglm-dev libglfw3-dev libglew-dev doxygen
+    - sudo pip install codecov
+    - mkdir out
+    - sudo apt-get install -y libglm-dev libglfw3-dev libglew-dev doxygen

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ jobs:
         skip_cleanup: true
         github_token: $GH_TOKEN
         local_dir: ./docs/html
-compiler: g++
+compiler: g++-8
 language: cpp
 notifications: never
 before_install:
   - sudo pip install codecov
   - mkdir out
-  - sudo apt-get install -y libglm-dev libglfw3-dev libglew-dev doxygen
+  - sudo apt-get install -y gcc-8 libglm-dev libglfw3-dev libglew-dev doxygen

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -5,11 +5,11 @@ Entity::Entity(int entityID) : id(entityID), componentBitset(0), typeToIndexMap(
 
 }
 
-void Entity::AddComponent(std::shared_ptr<Component> component)
+void Entity::AddComponent(std::unique_ptr<Component> component)
 {
-    this->components.push_back(component);
     this->componentBitset = this->componentBitset | component->GetComponentType();
-    this->typeToIndexMap[component->GetComponentType()] = this->components.size() - 1;
+    this->typeToIndexMap[component->GetComponentType()] = this->components.size();
+    this->components.push_back(std::move(component));
 }
 
 bool Entity::HasComponent(std::uint32_t componentType)

--- a/src/Entity.hpp
+++ b/src/Entity.hpp
@@ -15,15 +15,14 @@ class Entity
     public:
         Entity(int id);
 
-        void AddComponent(std::shared_ptr<Component> component);
+        void AddComponent(std::unique_ptr<Component> component);
         // Why do i have to pass both the component name as the template arg
         // and the type as the func arg ?
         template <typename T> 
         inline T* GetComponent(std::uint32_t type)
         {
-            std::shared_ptr<Component> baseComponent = this->components[this->typeToIndexMap[type]];
-            std::shared_ptr<T> component = std::static_pointer_cast<T>(baseComponent);
-            return component.get();
+            Component* baseComponent = this->components[this->typeToIndexMap[type]].get();
+            return static_cast<T*>(baseComponent);
         }
         bool HasComponent(std::uint32_t type);
         bool IsAlive();
@@ -35,6 +34,6 @@ class Entity
 
         bool isAlive;
         std::uint32_t componentBitset;
-        std::vector<std::shared_ptr<Component>> components;
+        std::vector<std::unique_ptr<Component>> components;
         std::unordered_map<std::uint32_t, int>  typeToIndexMap;
 };

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -127,7 +127,7 @@ void Game::InitConfig()
     glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, &unusedIds, true);
 }
 
-void Game::InitScene(std::string filename, std::vector<std::shared_ptr<Entity>>& entities)
+void Game::InitScene(std::string filename, std::vector<std::unique_ptr<Entity>>& entities)
 {
     unsigned int textureID = this->renderingSystem.CreateTexture("resources/DiffuseColor_Texture.png");
     tinyxml2::XMLDocument document;
@@ -199,7 +199,7 @@ void Game::InitScene(std::string filename, std::vector<std::shared_ptr<Entity>>&
             continue;
 
         std::shared_ptr<Geometry>   current = it->second;
-        std::shared_ptr<Entity>     entity = std::make_shared<Entity>(Entity(this->CreateEntityID()));
+        std::unique_ptr<Entity>     entity = std::make_unique<Entity>(this->CreateEntityID());
 
         bufferData = Loader::BuildBufferData(current);
         worldTransform = instanceGeometries[it->first]->matrix;
@@ -244,7 +244,7 @@ void Game::InitScene(std::string filename, std::vector<std::shared_ptr<Entity>>&
             entity->AddComponent(inputComponent);
         }
         // push_back
-        entities.push_back(entity);
+        entities.push_back(std::move(entity));
         // std::cout << entities.size() << std::endl;
     }
     // Push back an entity

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -214,7 +214,7 @@ void Game::InitScene(std::string filename, std::vector<std::unique_ptr<Entity>>&
         // RenderingComponent
         // we need to have
         // VAO, VBO and Texture loaded.
-        std::shared_ptr<RenderingComponent> renderingComponent = std::make_shared<RenderingComponent>(RenderingComponent(buffers.first, buffers.second, bufferData.size() / 3, textureID, ShaderType::NormalShader));
+        std::unique_ptr<RenderingComponent> renderingComponent = std::make_unique<RenderingComponent>(buffers.first, buffers.second, bufferData.size() / 3, textureID, ShaderType::NormalShader);
         // PhysicsComponent
         DynamicType type = DynamicType::Static;
         if (it->first == "Player")
@@ -223,7 +223,7 @@ void Game::InitScene(std::string filename, std::vector<std::unique_ptr<Entity>>&
         if (objectToColliders[it->first].size() > 0)
             std::cout << "setting mass " << std::endl;
             mass = 1.0f;
-        std::shared_ptr<PhysicsComponent> physicsComponent = std::make_shared<PhysicsComponent>(PhysicsComponent(1.f, translation, rotation, glm::mat3(1.f), type));
+        std::unique_ptr<PhysicsComponent> physicsComponent = std::make_unique<PhysicsComponent>(1.f, translation, rotation, glm::mat3(1.f), type);
         // assign colliders to component and insert into grid
         physicsComponent->colliders = objectToColliders[it->first];
         for (int k = 0;k < physicsComponent->colliders.size(); k++)
@@ -231,21 +231,19 @@ void Game::InitScene(std::string filename, std::vector<std::unique_ptr<Entity>>&
             physicsComponent->colliders[k]->entityID = entity->id;
         }
         this->physicsSystem.Insert(physicsComponent->colliders);
-        std::shared_ptr<TransformComponent> transformComponent = std::make_shared<TransformComponent>(TransformComponent(translation, rotation));
-        // Entity
+        std::unique_ptr<TransformComponent> transformComponent = std::make_unique<TransformComponent>(translation, rotation);
         
-        entity->AddComponent(renderingComponent);
-        entity->AddComponent(physicsComponent);
-        entity->AddComponent(transformComponent);
+        // Entity
+        entity->AddComponent(std::move(renderingComponent));
+        entity->AddComponent(std::move(physicsComponent));
+        entity->AddComponent(std::move(transformComponent));
         if (it->first == "Player")
         {
             this->playerID = entity->id;
-            std::shared_ptr<InputComponent> inputComponent = std::make_shared<InputComponent>(InputComponent());
-            entity->AddComponent(inputComponent);
+            std::unique_ptr<InputComponent> inputComponent = std::make_unique<InputComponent>();
+            entity->AddComponent(std::move(inputComponent));
         }
-        // push_back
         entities.push_back(std::move(entity));
-        // std::cout << entities.size() << std::endl;
     }
     // Push back an entity
 }

--- a/src/Game.hpp
+++ b/src/Game.hpp
@@ -34,7 +34,7 @@ class Game
 
         void Init();
         void InitConfig();
-        void InitScene(std::string filename, std::vector<std::shared_ptr<Entity>>& entities);
+        void InitScene(std::string filename, std::vector<std::unique_ptr<Entity>>& entities);
 
         void Run();
         void Update(float deltaTime);
@@ -53,7 +53,7 @@ class Game
         GLFWwindow*                 window;
 
         // Entities
-        std::vector<std::shared_ptr<Entity>> entities;
+        std::vector<std::unique_ptr<Entity>> entities;
 
         // Player
         int                         playerID;

--- a/src/Systems/Animation/AnimationSystem.cpp
+++ b/src/Systems/Animation/AnimationSystem.cpp
@@ -13,7 +13,7 @@ AnimationSystem::~AnimationSystem()
 
 }
 
-void AnimationSystem::Update(float deltaTime, std::vector<std::shared_ptr<Entity>>& entities, std::vector<Message>& events, std::vector<Message>& globalQueue)
+void AnimationSystem::Update(float deltaTime, std::vector<std::unique_ptr<Entity>>& entities, std::vector<Message>& events, std::vector<Message>& globalQueue)
 {
     // TODO : 
     for (int i = 0; i < entities.size(); i++)

--- a/src/Systems/Animation/AnimationSystem.hpp
+++ b/src/Systems/Animation/AnimationSystem.hpp
@@ -13,7 +13,7 @@ class AnimationSystem
         ~AnimationSystem();
 
         void Update(float deltaTime, 
-        			std::vector<std::shared_ptr<Entity>>& entities,
+        			std::vector<std::unique_ptr<Entity>>& entities,
         			std::vector<Message>& events,
         			std::vector<Message>& globalQueue);
 

--- a/src/Systems/Input/InputSystem.cpp
+++ b/src/Systems/Input/InputSystem.cpp
@@ -15,7 +15,7 @@ InputSystem::~InputSystem()
 
 }
 
-void InputSystem::Update(GLFWwindow* window, std::vector<std::shared_ptr<Entity>>& entities, std::vector<Message>& messages, std::vector<Message>& globalQueue)
+void InputSystem::Update(GLFWwindow* window, std::vector<std::unique_ptr<Entity>>& entities, std::vector<Message>& messages, std::vector<Message>& globalQueue)
 {
     // Note : we probably want to add animation triggers here.
     for (int i = 0; i < entities.size(); i++)

--- a/src/Systems/Input/InputSystem.hpp
+++ b/src/Systems/Input/InputSystem.hpp
@@ -14,7 +14,7 @@ class InputSystem
         ~InputSystem();
 
         void Update(GLFWwindow* window, 
-        			std::vector<std::shared_ptr<Entity>>& entities, 
+        			std::vector<std::unique_ptr<Entity>>& entities, 
         			std::vector<Message>& messages,
         			std::vector<Message>& globalQueue);
 

--- a/src/Systems/Physics/Grid.cpp
+++ b/src/Systems/Physics/Grid.cpp
@@ -17,7 +17,7 @@ Grid::Grid(float gridLength, float halfWidth) : \
         {
             float x = col * 2 * halfWidth + halfWidth;
             float z = row * 2 * halfWidth + halfWidth;
-            this->cells[row][col] = std::make_shared<Cell>(glm::vec3(x, 0.f, z), halfWidth, row, col);
+            this->cells[row][col] = std::make_unique<Cell>(glm::vec3(x, 0.f, z), halfWidth, row, col);
         }
     }
 }
@@ -131,7 +131,7 @@ int Grid::GetInsertCol(glm::vec3 point)
     while (high > low)
     {
         int mid = (high + low) / 2;
-        std::shared_ptr<Cell> midCell = this->cells[0][mid];
+        Cell* midCell = this->cells[0][mid].get();
         float distance = abs(point.x - midCell->center.x);
         if (distance < this->halfWidth)
         {
@@ -157,7 +157,7 @@ int Grid::GetInsertRow(glm::vec3 point)
     while (high > low)
     {
         int mid = (high + low) / 2;
-        std::shared_ptr<Cell> midCell = this->cells[mid][0];
+        Cell* midCell = this->cells[mid][0].get();
         float distance = abs(point.z - midCell->center.z);
         if (distance < this->halfWidth)
         {
@@ -199,7 +199,7 @@ std::vector<std::pair<int, int>> Grid::GetEligibleCells(int cellRow, int cellCol
     return result;
 }
 
-const std::vector< std::vector< std::shared_ptr<Cell>> > Grid::GetCells()
+const std::vector< std::vector< std::unique_ptr<Cell>> >& Grid::GetCells()
 {
     return this->cells;
 }

--- a/src/Systems/Physics/Grid.hpp
+++ b/src/Systems/Physics/Grid.hpp
@@ -51,7 +51,7 @@ class Grid
          */
         int  GetInsertCol(glm::vec3 point);
 
-        const std::vector< std::vector< std::shared_ptr<Cell>> > GetCells();
+        const std::vector< std::vector< std::unique_ptr<Cell>>>& GetCells();
 
     private:
 
@@ -59,5 +59,5 @@ class Grid
         float   halfWidth;
         float   gridLength;
         CollisionDetector collisionDetector;
-        std::vector< std::vector< std::shared_ptr<Cell> > > cells;
+        std::vector< std::vector< std::unique_ptr<Cell> > > cells;
 };

--- a/src/Systems/Physics/PhysicsSystem.cpp
+++ b/src/Systems/Physics/PhysicsSystem.cpp
@@ -23,7 +23,7 @@ void PhysicsSystem::Insert(std::vector<std::shared_ptr<Collider>>& colliders)
     }
 }
 
-void PhysicsSystem::Update(float deltaTime, std::vector<std::shared_ptr<Entity>>& entities, std::vector<Message>& messages, std::vector<Message>& globalQueue)
+void PhysicsSystem::Update(float deltaTime, std::vector<std::unique_ptr<Entity>>& entities, std::vector<Message>& messages, std::vector<Message>& globalQueue)
 {
     // build entity -> messages map
     std::unordered_map<int, std::vector<Message>> idToMessage;
@@ -93,7 +93,7 @@ void PhysicsSystem::Update(float deltaTime, std::vector<std::shared_ptr<Entity>>
     // TO DO
 }
 
-void PhysicsSystem::Solve(std::vector<std::shared_ptr<Entity>>& entities, std::vector<std::shared_ptr<Collision>>& collisions, std::unordered_map<int, int>& idToIndexMap)
+void PhysicsSystem::Solve(std::vector<std::unique_ptr<Entity>>& entities, std::vector<std::shared_ptr<Collision>>& collisions, std::unordered_map<int, int>& idToIndexMap)
 {
     float ELASTICITY = 1.f;
     for (int i = 0; i < collisions.size(); i++)

--- a/src/Systems/Physics/PhysicsSystem.cpp
+++ b/src/Systems/Physics/PhysicsSystem.cpp
@@ -39,7 +39,6 @@ void PhysicsSystem::Update(float deltaTime, std::vector<std::unique_ptr<Entity>>
         {
             PhysicsComponent* component = entities[i]->GetComponent<PhysicsComponent>(ComponentType::Physics);
             TransformComponent* transformComponent = entities[i]->GetComponent<TransformComponent>(ComponentType::Transform);
-
             // handle messages for the current entity
             if (idToMessage.find(entities[i]->id) != idToMessage.end())
                 this->HandleMessages(idToMessage[entities[i]->id], component);

--- a/src/Systems/Physics/PhysicsSystem.hpp
+++ b/src/Systems/Physics/PhysicsSystem.hpp
@@ -18,7 +18,7 @@ class PhysicsSystem
 
         void Insert(std::vector<std::shared_ptr<Collider>>& colliders);
         void Update(float deltaTime, 
-                    std::vector<std::shared_ptr<Entity>>& entities,
+                    std::vector<std::unique_ptr<Entity>>& entities,
                     std::vector<Message>& messages,
                     std::vector<Message>& globalQueue);
         /**
@@ -27,7 +27,7 @@ class PhysicsSystem
         https://www.scss.tcd.ie/~manzkem/CS7057/cs7057-1516-09-CollisionResponse-mm.pdf
         https://en.wikipedia.org/wiki/Collision_response#Impulse-based_reaction_model
         */
-        void Solve(	std::vector<std::shared_ptr<Entity>>& entities, 
+        void Solve(	std::vector<std::unique_ptr<Entity>>& entities, 
         			std::vector<std::shared_ptr<Collision>>& collisions, 
         			std::unordered_map<int, int>& idToIndexMap);
 

--- a/src/Systems/Rendering/RenderingSystem.cpp
+++ b/src/Systems/Rendering/RenderingSystem.cpp
@@ -33,7 +33,7 @@ void RenderingSystem::AddShaders(std::vector<std::string> shaders, std::vector<s
     }
 }
 
-void RenderingSystem::Update(std::vector<std::shared_ptr<Entity>>& entities, int playerID, std::vector<Message>& messages, std::vector<Message>& globalQueue)
+void RenderingSystem::Update(std::vector<std::unique_ptr<Entity>>& entities, int playerID, std::vector<Message>& messages, std::vector<Message>& globalQueue)
 {
     // build entity -> messages map
     std::unordered_map<int, std::vector<Message>> idToMessage;

--- a/src/Systems/Rendering/RenderingSystem.hpp
+++ b/src/Systems/Rendering/RenderingSystem.hpp
@@ -16,7 +16,7 @@ class RenderingSystem
         RenderingSystem();
         ~RenderingSystem();
         void AddShaders(std::vector<std::string> shaders, std::vector<std::string> shadowShaders);
-        void Update(std::vector<std::shared_ptr<Entity>>& entities,
+        void Update(std::vector<std::unique_ptr<Entity>>& entities,
                     int playerID,
                     std::vector<Message>& messages,
                     std::vector<Message>& globalQueue);

--- a/test/GridTest.cpp
+++ b/test/GridTest.cpp
@@ -7,7 +7,7 @@
 TEST_CASE("Grid Test")
 {
 	Grid grid(200.f, 5.f);
-	const std::vector< std::vector< std::shared_ptr<Cell>> > cells = grid.GetCells();
+	const std::vector< std::vector< std::unique_ptr<Cell>> >& cells = grid.GetCells();
 
 	REQUIRE(cells.size() == 20);
 	REQUIRE(cells[0].size() == 20);
@@ -47,25 +47,25 @@ TEST_CASE("Grid Test")
 
 	SECTION("Test insertion")
 	{
-		std::shared_ptr<Cell> cell1 = grid.GetCells()[0][0];
+		Cell* cell1 = grid.GetCells()[0][0].get();
 		const std::vector<std::shared_ptr<Collider>> dynamicColliders1 = cell1->GetDynamicColliders();
 		const std::vector<std::shared_ptr<Collider>> staticColliders1 = cell1->GetStaticColliders();
 		REQUIRE(dynamicColliders1.size() == 1);
 		REQUIRE(staticColliders1.size() == 1);
 
-		std::shared_ptr<Cell> cell2 = grid.GetCells()[1][0];
+		Cell* cell2 = grid.GetCells()[1][0].get();
 		const std::vector<std::shared_ptr<Collider>> dynamicColliders2 = cell2->GetDynamicColliders();
 		const std::vector<std::shared_ptr<Collider>> staticColliders2 = cell2->GetStaticColliders();
 		REQUIRE(dynamicColliders2.size() == 0);
 		REQUIRE(staticColliders2.size() == 1);
 
-		std::shared_ptr<Cell> cell3 = grid.GetCells()[0][1];
+		Cell* cell3 = grid.GetCells()[0][1].get();
 		const std::vector<std::shared_ptr<Collider>> dynamicColliders3 = cell3->GetDynamicColliders();
 		const std::vector<std::shared_ptr<Collider>> staticColliders3 = cell3->GetStaticColliders();
 		REQUIRE(dynamicColliders3.size() == 2);
 		REQUIRE(staticColliders3.size() == 0);
 
-		std::shared_ptr<Cell> cell4 = grid.GetCells()[1][1];
+		Cell* cell4 = grid.GetCells()[1][1].get();
 		const std::vector<std::shared_ptr<Collider>> dynamicColliders4 = cell4->GetDynamicColliders();
 		const std::vector<std::shared_ptr<Collider>> staticColliders4 = cell4->GetStaticColliders();
 		REQUIRE(dynamicColliders4.size() == 0);
@@ -77,7 +77,7 @@ TEST_CASE("Grid Test")
 	{
 		grid.Remove(plane1);
 		grid.Remove(box1);
-		std::shared_ptr<Cell> cell1 = grid.GetCells()[0][0];
+		Cell* cell1 = grid.GetCells()[0][0].get();
 		const std::vector<std::shared_ptr<Collider>> dynamicColliders1 = cell1->GetDynamicColliders();
 		const std::vector<std::shared_ptr<Collider>> staticColliders1 = cell1->GetStaticColliders();
 		REQUIRE(dynamicColliders1.size() == 0);

--- a/test/InputSystemTest.cpp
+++ b/test/InputSystemTest.cpp
@@ -13,11 +13,11 @@ extern float EPSILON;
 TEST_CASE("Input System Test")
 {
 	std::shared_ptr<InputComponent> component = std::make_shared<InputComponent>(InputComponent());
-	std::shared_ptr<Entity> entity = std::make_shared<Entity>(Entity(12));
+	std::unique_ptr<Entity> entity = std::make_unique<Entity>(12);
 	entity->AddComponent(component);
 
-	std::vector<std::shared_ptr<Entity>> entities;
-	entities.push_back(entity);
+	std::vector<std::unique_ptr<Entity>> entities;
+	entities.push_back(std::move(entity));
 
 	std::vector<Message> messages;
 	std::vector<Message> globalQueue;

--- a/test/InputSystemTest.cpp
+++ b/test/InputSystemTest.cpp
@@ -12,9 +12,9 @@ extern float EPSILON;
 
 TEST_CASE("Input System Test")
 {
-	std::shared_ptr<InputComponent> component = std::make_shared<InputComponent>(InputComponent());
+	std::unique_ptr<InputComponent> component = std::make_unique<InputComponent>();
 	std::unique_ptr<Entity> entity = std::make_unique<Entity>(12);
-	entity->AddComponent(component);
+	entity->AddComponent(std::move(component));
 
 	std::vector<std::unique_ptr<Entity>> entities;
 	entities.push_back(std::move(entity));

--- a/test/PhysicsSystemTest.cpp
+++ b/test/PhysicsSystemTest.cpp
@@ -32,7 +32,7 @@ TEST_CASE("PhysicsSystem Test")
 	std::shared_ptr<PhysicsComponent> component1 = std::make_shared<PhysicsComponent>(PhysicsComponent(mass, center1, orientation, inertiaTensor, DynamicType::Static));
 	std::shared_ptr<TransformComponent> transformComponent1 = std::make_shared<TransformComponent>(TransformComponent(center1, orientation));
 	component1->colliders.push_back(plane1);
-	std::shared_ptr<Entity> entity1 = std::make_shared<Entity>(Entity(1));
+	std::unique_ptr<Entity> entity1 = std::make_unique<Entity>(1);
 	entity1->AddComponent(component1);
 	entity1->AddComponent(transformComponent1);
 
@@ -54,13 +54,15 @@ TEST_CASE("PhysicsSystem Test")
 	std::shared_ptr<TransformComponent> transformComponent2 = std::make_shared<TransformComponent>(TransformComponent(box_center1, orientation));
 	component2->velocity = glm::vec3(-19.f, 0.f, 0.f);
 	component2->colliders.push_back(box1);
-	std::shared_ptr<Entity> entity2 = std::make_shared<Entity>(Entity(3));
+	std::unique_ptr<Entity> entity2 = std::make_unique<Entity>(3);
 	entity2->AddComponent(component2);
 	entity2->AddComponent(transformComponent2);
 	std::vector<std::shared_ptr<Collider>> colliders{plane1, box1};
 	physicsSystem.Insert(colliders);
 
-	std::vector<std::shared_ptr<Entity>> entities{entity1, entity2};
+	std::vector<std::unique_ptr<Entity>> entities;
+	entities.push_back(std::move(entity1));
+	entities.push_back(std::move(entity2));
 	std::vector<Message> messages;
 	std::vector<Message> globalQueue;
 	physicsSystem.Update(0.0166f, entities, messages, globalQueue);

--- a/test/PhysicsSystemTest.cpp
+++ b/test/PhysicsSystemTest.cpp
@@ -12,7 +12,6 @@ TEST_CASE("PhysicsSystem Test")
 {
 	// System setup
 	PhysicsSystem physicsSystem(200.f, 10.f);
-
 	// Entity setup
 	// Plane object
 	glm::quat orientation(1.0, 0.f, 0.f, 0.f);
@@ -29,13 +28,12 @@ TEST_CASE("PhysicsSystem Test")
 		coeff*4, 0.f, 0.f,
 		0.f, coeff*4, 0.f,
 		0.f, 0.f, coeff*8);
-	std::shared_ptr<PhysicsComponent> component1 = std::make_shared<PhysicsComponent>(PhysicsComponent(mass, center1, orientation, inertiaTensor, DynamicType::Static));
-	std::shared_ptr<TransformComponent> transformComponent1 = std::make_shared<TransformComponent>(TransformComponent(center1, orientation));
+	std::unique_ptr<PhysicsComponent> component1 = std::make_unique<PhysicsComponent>(mass, center1, orientation, inertiaTensor, DynamicType::Static);
+	std::unique_ptr<TransformComponent> transformComponent1 = std::make_unique<TransformComponent>(center1, orientation);
 	component1->colliders.push_back(plane1);
 	std::unique_ptr<Entity> entity1 = std::make_unique<Entity>(1);
-	entity1->AddComponent(component1);
-	entity1->AddComponent(transformComponent1);
-
+	entity1->AddComponent(std::move(component1));
+	entity1->AddComponent(std::move(transformComponent1));
 	// aabb object
 	glm::vec3 box_center1 = glm::vec3(4.f, 2.f, 2.f);
 	glm::vec3 axisRadii1 = glm::vec3(2.f,2.f,2.f);
@@ -50,16 +48,15 @@ TEST_CASE("PhysicsSystem Test")
 		0.f, coeff*(xSquared + zSquared), 0.f,
 		0.f, 0.f, coeff*(xSquared + ySquared));
 	std::shared_ptr<AABB> box1 = std::make_shared<AABB>(AABB(3, box_center1, ColliderType::BOX, DynamicType::Dynamic, axisRadii1));
-	std::shared_ptr<PhysicsComponent> component2 = std::make_shared<PhysicsComponent>(PhysicsComponent(mass, box_center1, orientation, inertiaTensorBox, DynamicType::WithPhysics));
-	std::shared_ptr<TransformComponent> transformComponent2 = std::make_shared<TransformComponent>(TransformComponent(box_center1, orientation));
+	std::unique_ptr<PhysicsComponent> component2 = std::make_unique<PhysicsComponent>(mass, box_center1, orientation, inertiaTensorBox, DynamicType::WithPhysics);
+	std::unique_ptr<TransformComponent> transformComponent2 = std::make_unique<TransformComponent>(box_center1, orientation);
 	component2->velocity = glm::vec3(-19.f, 0.f, 0.f);
 	component2->colliders.push_back(box1);
 	std::unique_ptr<Entity> entity2 = std::make_unique<Entity>(3);
-	entity2->AddComponent(component2);
-	entity2->AddComponent(transformComponent2);
+	entity2->AddComponent(std::move(component2));
+	entity2->AddComponent(std::move(transformComponent2));
 	std::vector<std::shared_ptr<Collider>> colliders{plane1, box1};
 	physicsSystem.Insert(colliders);
-
 	std::vector<std::unique_ptr<Entity>> entities;
 	entities.push_back(std::move(entity1));
 	entities.push_back(std::move(entity2));


### PR DESCRIPTION
### Problem

We are using `shared_ptr` way too often even when it is not required.

----------------------------------------------------------------------------------------------------------------------

### Solution

Moved the `Entity`, `Cell`, `Component` classes to use combination of `unique_ptr` and raw pointers instead of `shared_ptr`.