### PR TITLE
tOV5PZ3T | Updated the clipping routing

### DIFF
--- a/scripts/.breakpoints
+++ b/scripts/.breakpoints
@@ -1,0 +1,2 @@
+break ColliderBuilder::MergeFaces(std::vector<std::unique_ptr<cFace, std::default_delete<cFace> >, std::allocator<std::unique_ptr<cFace, std::default_delete<cFace> > > >&, std::vector<ColliderFace, std::allocator<ColliderFace> >&, std::vector<std::pair<int, int>, std::allocator<std::pair<int, int> > >&, std::vector<glm::vec<3, float, (glm::qualifier)0>, std::allocator<glm::vec<3, float, (glm::qualifier)0> > >&)
+break CollisionDetector::Collide(std::shared_ptr<Collider>, std::shared_ptr<Collider>)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -218,9 +218,6 @@ void Game::InitScene(std::string filename, std::vector<std::unique_ptr<Entity>>&
     //     if (it->first == "Player")
     //         type = DynamicType::Dynamic;
     //     float mass = 1.0f;
-    //     if (objectToColliders[it->first].size() > 0)
-    //         std::cout << "setting mass " << std::endl;
-    //         mass = 1.0f;
     //     std::unique_ptr<PhysicsComponent> physicsComponent = std::make_unique<PhysicsComponent>(1.f, translation, rotation, glm::mat3(1.f), type);
     //     // assign colliders to component and insert into grid
     //     physicsComponent->colliders = objectToColliders[it->first];

--- a/src/Systems/Physics/CollisionDetector.hpp
+++ b/src/Systems/Physics/CollisionDetector.hpp
@@ -35,9 +35,9 @@ class CollisionDetector
         bool CheckEdges(SATData& data, std::shared_ptr<Collider> first, std::shared_ptr<Collider> second);
 
         /**
-        GetCollisionPoints clips the edges of the first against the faces of the second.
+        the first collider will hold the reference face and the second will hold the incident face.
         */
-        std::vector<glm::vec3> GetCollisionPoints(SATData& data, std::shared_ptr<Collider> first, std::shared_ptr<Collider> second);
+        std::vector<glm::vec3> GetContactPoints(SATData& data, std::shared_ptr<Collider> first, std::shared_ptr<Collider> second);
 
         // Helpers
         /** 
@@ -63,11 +63,8 @@ class CollisionDetector
         Clips a given list of edges against a plane. Used in collision detection to determine the contact
         points that are sent to the solver.
          */
-        std::vector<glm::vec3> Clip(std::shared_ptr<Collider> first, std::shared_ptr<Collider> second, std::vector<ColliderFace>& planes);
+        std::vector<glm::vec3> Clip(std::vector<glm::vec3>& points, std::vector<std::pair<glm::vec3, glm::vec3>>& planes);
 
-        std::vector<ColliderFace> GetAdjacentFaces(SATData& data, const std::vector<ColliderFace>& faces);
-
-        bool ContainsPoint(glm::vec3 point, std::vector<glm::vec3>& points);
         /** 
         GetSupport Points returns the the farthest point in the given direction.
         It is an O(n) operation, but the assumption here is that we wont have massive polyhedras.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5,3 +5,13 @@ void printVector(glm::vec3 vector, std::string name)
 {
 	std::cout << name << ": x = " << vector.x << " y = " << vector.y << " z = " << vector.z << std::endl;
 }
+
+void print2DVector(std::vector<glm::vec3> vector, std::string name)
+{
+	std::cout << "------- 2D " << name << "-------" << std::endl;
+	for (int i = 0; i < vector.size(); ++i)
+	{
+		printVector(vector[i]);
+	}
+	std::cout << "---------------------" << std::endl;
+}

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -1,5 +1,7 @@
 #pragma once
 #include <glm/glm.hpp>
 #include <string>
+#include <vector>
 
 void printVector(glm::vec3 vector, std::string name = "Vector");
+void print2DVector(std::vector<glm::vec3> vector, std::string name = "Vector");

--- a/test/TestColliderBuilder.cpp
+++ b/test/TestColliderBuilder.cpp
@@ -304,3 +304,115 @@ TEST_CASE("Face points test")
 		REQUIRE(found == true);
 	}
 }
+
+TEST_CASE("Deformed box produces correct points on faces 1")
+{
+	std::vector<glm::vec3> points;
+	points.push_back(glm::vec3(0.f, 0.f, 0.f)); // 0 A
+	points.push_back(glm::vec3(2.f, 0.f, 0.f)); // 1 B
+	points.push_back(glm::vec3(0.f, 1.f, 0.f)); // 2 C
+	points.push_back(glm::vec3(2.f, 2.f, 0.f)); // 3 D
+	points.push_back(glm::vec3(0.f, 0.f, 0.7f)); // 4 E
+	points.push_back(glm::vec3(2.f, 0.f, 2.f)); // 5 F
+	points.push_back(glm::vec3(2.f, 2.f, 2.f)); // 6 G
+	points.push_back(glm::vec3(0.f, 1.f, 1.f)); // 7 H
+
+	std::shared_ptr<Collider> collider = ColliderBuilder::Build(1, DynamicType::Static, points);
+
+	std::vector<std::vector<int>> expectedFacePoints;
+	expectedFacePoints.push_back(std::vector<int>{1, 3, 6, 5});
+	expectedFacePoints.push_back(std::vector<int>{6, 3, 7, 2});
+	expectedFacePoints.push_back(std::vector<int>{5, 1, 4, 0});
+	expectedFacePoints.push_back(std::vector<int>{1, 3, 0, 2});
+	expectedFacePoints.push_back(std::vector<int>{7, 2, 4, 0});
+	expectedFacePoints.push_back(std::vector<int>{5, 6, 7});
+	expectedFacePoints.push_back(std::vector<int>{4, 5, 7});
+
+	const std::vector<ColliderFace>& faces = collider->GetFaces();
+
+	REQUIRE(expectedFacePoints.size() == faces.size());
+	for (int i = 0; i < expectedFacePoints.size(); i++)
+	{
+		bool found = false;
+		for (int j = 0; j < faces.size(); j++)
+		{
+			int count = 0;
+			for (int x = 0; x < faces[j].points.size(); x++)
+			{
+				for (int k = 0; k < expectedFacePoints[i].size(); k++)
+				{
+					if (faces[j].points[x] == expectedFacePoints[i][k])
+						count += 1;
+				}
+			}
+			if (count == expectedFacePoints[i].size())
+				found = true;
+		}
+		REQUIRE(found == true);
+	}
+}
+
+TEST_CASE("Deformed box produces correct points on faces 2")
+{
+	std::vector<glm::vec3> points;
+	points.push_back(glm::vec3(1.5f, 1.f, 0.5f));	 // 0
+	points.push_back(glm::vec3(3.f, 1.f, 0.f)); 	// 1
+	points.push_back(glm::vec3(3.f, 2.58f, 0.f)); 	// 2
+	points.push_back(glm::vec3(1.5f, 2.58f, 0.5f)); // 3
+	points.push_back(glm::vec3(3.5f, 1.f, 1.5f)); 	// 4
+	points.push_back(glm::vec3(2.f, 2.58f, 2.f)); 	// 5
+	points.push_back(glm::vec3(2.f, 1.f, 2.f)); 	// 6
+	points.push_back(glm::vec3(3.5f, 2.58f, 1.5f)); // 7
+	std::shared_ptr<Collider> collider = ColliderBuilder::Build(1, DynamicType::Static, points);
+
+	std::vector<std::vector<int>> expectedFacePoints;
+	expectedFacePoints.push_back(std::vector<int>{0, 1, 6, 4});
+	expectedFacePoints.push_back(std::vector<int>{1, 2, 7, 4});
+	expectedFacePoints.push_back(std::vector<int>{5, 7, 2, 3});
+	expectedFacePoints.push_back(std::vector<int>{0, 3, 5, 6});
+	expectedFacePoints.push_back(std::vector<int>{4, 5, 6, 7});
+	expectedFacePoints.push_back(std::vector<int>{0, 1, 2, 3});
+
+	const std::vector<ColliderFace>& faces = collider->GetFaces();
+
+	REQUIRE(expectedFacePoints.size() == faces.size());
+	for (int i = 0; i < expectedFacePoints.size(); i++)
+	{
+		bool found = false;
+		for (int j = 0; j < faces.size(); j++)
+		{
+			int count = 0;
+			for (int x = 0; x < faces[j].points.size(); x++)
+			{
+				for (int k = 0; k < expectedFacePoints[i].size(); k++)
+				{
+					if (faces[j].points[x] == expectedFacePoints[i][k])
+						count += 1;
+				}
+			}
+			if (count == expectedFacePoints[i].size())
+				found = true;
+		}
+		REQUIRE(found == true);
+	}
+}
+
+TEST_CASE("Deformed box produces 6 faces and 12 edges")
+{
+	std::vector<glm::vec3> points;
+	points.push_back(glm::vec3(0.72f, -1.29f, 1.5f));
+	points.push_back(glm::vec3(3.f, 1.5f, 1.5f));
+	points.push_back(glm::vec3(2.74f, -2.94f, -0.98f));
+	points.push_back(glm::vec3(5.02f, -.16f, -0.98f));
+	points.push_back(glm::vec3(2.64f, -2.86f, 4.12f));
+	points.push_back(glm::vec3(4.92f, -.07f, 4.12f));
+	points.push_back(glm::vec3(4.66f, -4.51f, 1.64f));
+	points.push_back(glm::vec3(6.94f, -1.72f, 1.64f));
+	std::shared_ptr<Collider> collider = ColliderBuilder::Build(5, DynamicType::Static, points);
+
+	const std::vector<ColliderFace>& faces = collider->GetFaces();
+	const std::vector<std::pair<int, int>>& edges = collider->GetEdges();
+
+	REQUIRE(faces.size() == 6);
+	REQUIRE(edges.size() == 12);
+}

--- a/test/TestCollisionDetector.cpp
+++ b/test/TestCollisionDetector.cpp
@@ -21,25 +21,25 @@ TEST_CASE("CollisionDetector Test")
 	*/
 
 	std::vector<glm::vec3> points1;
-	points1.push_back(glm::vec3(0.f, 0.f, 0.f));
-	points1.push_back(glm::vec3(2.f, 0.f, 0.f));
-	points1.push_back(glm::vec3(2.f, 2.f, 0.f));
-	points1.push_back(glm::vec3(0.f, 2.f, 0.f));
-	points1.push_back(glm::vec3(0.f, 0.f, 2.f));
-	points1.push_back(glm::vec3(2.f, 0.f, 2.f));
-	points1.push_back(glm::vec3(2.f, 2.f, 2.f));
-	points1.push_back(glm::vec3(0.f, 2.f, 2.f));
+	points1.push_back(glm::vec3(0.f, 0.f, 0.f)); // 0
+	points1.push_back(glm::vec3(2.f, 0.f, 0.f)); // 1
+	points1.push_back(glm::vec3(2.f, 2.f, 0.f)); // 2
+	points1.push_back(glm::vec3(0.f, 2.f, 0.f)); // 3
+	points1.push_back(glm::vec3(0.f, 0.f, 2.f)); // 4
+	points1.push_back(glm::vec3(2.f, 0.f, 2.f)); // 5
+	points1.push_back(glm::vec3(2.f, 2.f, 2.f)); // 6
+	points1.push_back(glm::vec3(0.f, 2.f, 2.f)); // 7
 	std::shared_ptr<Collider> collider1 = ColliderBuilder::Build(1, DynamicType::Static, points1);
 
 	std::vector<glm::vec3> points2;
-	points2.push_back(glm::vec3(1.5f, 1.f, 0.5f));
-	points2.push_back(glm::vec3(3.f, 1.f, 0.f));
-	points2.push_back(glm::vec3(3.f, 2.58f, 0.f));
-	points2.push_back(glm::vec3(1.5f, 2.58f, 0.5f));
-	points2.push_back(glm::vec3(3.5f, 1.f, 1.5f));
-	points2.push_back(glm::vec3(2.f, 2.58f, 2.f));
-	points2.push_back(glm::vec3(2.f, 1.f, 2.f));
-	points2.push_back(glm::vec3(3.5f, 2.58f, 1.5f));
+	points2.push_back(glm::vec3(1.5f, 1.f, 0.5f));	 // 0
+	points2.push_back(glm::vec3(3.f, 1.f, 0.f)); 	// 1
+	points2.push_back(glm::vec3(3.f, 2.58f, 0.f)); 	// 2
+	points2.push_back(glm::vec3(1.5f, 2.58f, 0.5f)); // 3
+	points2.push_back(glm::vec3(3.5f, 1.f, 1.5f)); 	// 4
+	points2.push_back(glm::vec3(2.f, 2.58f, 2.f)); 	// 5
+	points2.push_back(glm::vec3(2.f, 1.f, 2.f)); 	// 6
+	points2.push_back(glm::vec3(3.5f, 2.58f, 1.5f)); // 7
 	std::shared_ptr<Collider> collider2 = ColliderBuilder::Build(2, DynamicType::Static, points2);
 
 	std::vector<glm::vec3> points3;
@@ -54,14 +54,14 @@ TEST_CASE("CollisionDetector Test")
 	std::shared_ptr<Collider> collider3 = ColliderBuilder::Build(3, DynamicType::Static, points3);
 
 	std::vector<glm::vec3> points4;
-	points4.push_back(glm::vec3(0.f, 1.5f, 0.f));
-	points4.push_back(glm::vec3(2.f, 1.5f, 0.f));
-	points4.push_back(glm::vec3(2.f, 3.5f, 0.f));
-	points4.push_back(glm::vec3(0.f, 3.5f, 0.f));
-	points4.push_back(glm::vec3(0.f, 1.5f, 2.f));
-	points4.push_back(glm::vec3(2.f, 1.5f, 2.f));
-	points4.push_back(glm::vec3(2.f, 3.5f, 2.f));
-	points4.push_back(glm::vec3(0.f, 3.5f, 2.f));
+	points4.push_back(glm::vec3(0.f, 1.5f, 0.5f));
+	points4.push_back(glm::vec3(2.f, 1.5f, 0.5f));
+	points4.push_back(glm::vec3(2.f, 3.5f, 0.5f));
+	points4.push_back(glm::vec3(0.f, 3.5f, 0.5f));
+	points4.push_back(glm::vec3(0.f, 1.5f, 2.5f));
+	points4.push_back(glm::vec3(2.f, 1.5f, 2.5f));
+	points4.push_back(glm::vec3(2.f, 3.5f, 2.5f));
+	points4.push_back(glm::vec3(0.f, 3.5f, 2.5f));
 	std::shared_ptr<Collider> collider4 = ColliderBuilder::Build(4, DynamicType::Static, points4);
 
 	std::vector<glm::vec3> points5;
@@ -85,25 +85,60 @@ TEST_CASE("CollisionDetector Test")
 	points6.push_back(glm::vec3(1.f, 2.5f, 1.6f));
 	points6.push_back(glm::vec3(1.6f, 2.5f, 1.6f));
 	std::shared_ptr<Collider> collider6 = ColliderBuilder::Build(6, DynamicType::Static, points6);
+
+	std::vector<glm::vec3> points7;
+	points7.push_back(glm::vec3(3.f, 1.5f, 1.95f));
+	points7.push_back(glm::vec3(3.f, 1.f, 1.95f));
+	points7.push_back(glm::vec3(-1.f, 1.5f, 1.95f));
+	points7.push_back(glm::vec3(-1.f, 1.f, 1.95f));
+	points7.push_back(glm::vec3(3.f, 1.5f, 2.1f));
+	points7.push_back(glm::vec3(3.f, 1.f, 2.1f));
+	points7.push_back(glm::vec3(-1.f, 1.5f, 2.1f));
+	points7.push_back(glm::vec3(-1.f, 1.f, 2.1f));
+	std::shared_ptr<Collider> collider7 = ColliderBuilder::Build(7, DynamicType::Static, points7);
 	
 	SECTION("Collider 1/2 - face/vertex")
 	{
+		std::vector<glm::vec3> expectedPoints;
+		expectedPoints.push_back(glm::vec3(1.5f, 1.f, 0.5f));
+		expectedPoints.push_back(glm::vec3(2.f, 2.f, 2.f));
+		expectedPoints.push_back(glm::vec3(1.5f, 2.f, 0.5f));
 		std::shared_ptr<Collision> collision1 = detector.Collide(collider1, collider2);
 		REQUIRE(collision1 != nullptr);
 		REQUIRE(glm::all(glm::epsilonEqual(glm::vec3(-1.f, 0.f, 0.f), collision1->contacts[0].contactNormal, detector.tolerance)));
-		REQUIRE(collision1->contacts.size() == 2);
+		REQUIRE(collision1->contacts.size() == 3);
 
-		REQUIRE(glm::all(glm::epsilonEqual(glm::vec3(1.5f, 1.f, 0.5f), collision1->contacts[0].contactPoint, detector.tolerance)));
-		REQUIRE(glm::all(glm::epsilonEqual(glm::vec3(2.f, 1.f, 2.f), collision1->contacts[1].contactPoint, detector.tolerance)));
+		for (int i = 0; i < expectedPoints.size(); i++)
+		{
+			bool found = false;
+			for (int j = 0; j < collision1->contacts.size(); j++)
+			{
+				if (glm::all(glm::epsilonEqual(expectedPoints[i], collision1->contacts[j].contactPoint, detector.tolerance)))
+					found = true;
+			}
+			REQUIRE(found == true);
+		}
 	}
 	SECTION("Collider 2/1 - face/vertex")
 	{
+		std::vector<glm::vec3> expectedPoints;
+		expectedPoints.push_back(glm::vec3(1.5f, 1.f, 0.5f));
+		expectedPoints.push_back(glm::vec3(2.f, 2.f, 2.f));
+		expectedPoints.push_back(glm::vec3(1.5f, 2.f, 0.5f));
 		std::shared_ptr<Collision> collision1 = detector.Collide(collider2, collider1);
 		REQUIRE(collision1 != nullptr);
 		REQUIRE(glm::all(glm::epsilonEqual(glm::vec3(1.f, 0.f, 0.f), collision1->contacts[0].contactNormal, detector.tolerance)));
-		REQUIRE(collision1->contacts.size() == 2);
-		REQUIRE(glm::all(glm::epsilonEqual(glm::vec3(1.5f, 1.f, 0.5f), collision1->contacts[0].contactPoint, detector.tolerance)));
-		REQUIRE(glm::all(glm::epsilonEqual(glm::vec3(2.f, 1.f, 2.f), collision1->contacts[1].contactPoint, detector.tolerance)));
+		REQUIRE(collision1->contacts.size() == 3);
+		for (int i = 0; i < expectedPoints.size(); i++)
+		{
+			bool found = false;
+			for (int j = 0; j < collision1->contacts.size(); j++)
+			{
+				if (glm::all(glm::epsilonEqual(expectedPoints[i], collision1->contacts[j].contactPoint, detector.tolerance)))
+					found = true;
+			}
+			REQUIRE(found == true);
+		}
 	}
 	SECTION("Collider 1/3 - face/edge")
 	{
@@ -129,12 +164,10 @@ TEST_CASE("CollisionDetector Test")
 		std::shared_ptr<Collision> collision = detector.Collide(collider1, collider4);
 		REQUIRE(collision != nullptr);
 		REQUIRE(glm::all(glm::epsilonEqual(glm::vec3(0.f, -1.f, 0.f), collision->contacts[0].contactNormal, detector.tolerance)));
-		REQUIRE(collision->contacts.size() == 4);
+		REQUIRE(collision->contacts.size() == 2);
 		std::vector<glm::vec3> expectedPoints;
-		expectedPoints.push_back(glm::vec3(2.f, 2.f, 0.f));
-		expectedPoints.push_back(glm::vec3(0.f, 2.f, 0.f));
-		expectedPoints.push_back(glm::vec3(0.f, 2.f, 2.f));
 		expectedPoints.push_back(glm::vec3(2.f, 2.f, 2.f));
+		expectedPoints.push_back(glm::vec3(0.f, 2.f, 0.5f));
 
 		for (int i = 0; i < expectedPoints.size(); i++)
 		{
@@ -169,11 +202,93 @@ TEST_CASE("CollisionDetector Test")
 		REQUIRE(penetrationCheck >= 0.f);
 		REQUIRE(penetrationCheck < 0.005f);
 	}
-	// SECTION("Collider 1/6 - big face/small face")
-	// {
-	// 	// TODO : FIX
-	// 	std::shared_ptr<Collision> collision = detector.Collide(collider1, collider6);
-	// 	REQUIRE(collision != nullptr);
-	// 	REQUIRE(collision->contacts.size() == 4);
-	// }
+	SECTION("Collider 1/6 - big face/small face")
+	{
+		std::vector<glm::vec3> expectedPoints;
+		expectedPoints.push_back(glm::vec3(1.6f, 2.f, 1.f));
+		expectedPoints.push_back(glm::vec3(1.f, 2.f, 1.f));
+		expectedPoints.push_back(glm::vec3(1.6f, 2.f, 1.6f));
+		expectedPoints.push_back(glm::vec3(1.6f, 2.f, 1.6f));
+		std::shared_ptr<Collision> collision = detector.Collide(collider1, collider6);
+		REQUIRE(collision != nullptr);
+		REQUIRE(collision->contacts.size() == 4);
+
+		for (int i = 0; i < expectedPoints.size(); i++)
+		{
+			bool found = false;
+			for (int j = 0; j < collision->contacts.size(); j++)
+			{
+				if (glm::all(glm::epsilonEqual(expectedPoints[i], collision->contacts[j].contactPoint, detector.tolerance)))
+					found = true;
+			}
+			REQUIRE(found == true);
+		}
+	}
+	SECTION("Collider 6/1 - big face/small face")
+	{
+		std::vector<glm::vec3> expectedPoints;
+		expectedPoints.push_back(glm::vec3(1.6f, 1.9f, 1.f));
+		expectedPoints.push_back(glm::vec3(1.f, 1.9f, 1.f));
+		expectedPoints.push_back(glm::vec3(1.6f, 1.9f, 1.6f));
+		expectedPoints.push_back(glm::vec3(1.6f, 1.9f, 1.6f));
+		std::shared_ptr<Collision> collision = detector.Collide(collider6, collider1);
+		REQUIRE(collision != nullptr);
+		REQUIRE(collision->contacts.size() == 4);
+
+		for (int i = 0; i < expectedPoints.size(); i++)
+		{
+			bool found = false;
+			for (int j = 0; j < collision->contacts.size(); j++)
+			{
+				if (glm::all(glm::epsilonEqual(expectedPoints[i], collision->contacts[j].contactPoint, detector.tolerance)))
+					found = true;
+			}
+			REQUIRE(found == true);
+		}
+	}
+
+	SECTION("Collider 1/7 - big face/small face")
+	{
+		std::vector<glm::vec3> expectedPoints;
+		expectedPoints.push_back(glm::vec3(0.f, 1.5f, 2.f));
+		expectedPoints.push_back(glm::vec3(0.f, 1.f, 2.f));
+		expectedPoints.push_back(glm::vec3(2.f, 1.f, 2.f));
+		expectedPoints.push_back(glm::vec3(2.f, 1.5f, 2.f));
+		std::shared_ptr<Collision> collision = detector.Collide(collider1, collider7);
+		REQUIRE(collision != nullptr);
+		REQUIRE(collision->contacts.size() == 4);
+
+		for (int i = 0; i < expectedPoints.size(); i++)
+		{
+			bool found = false;
+			for (int j = 0; j < collision->contacts.size(); j++)
+			{
+				if (glm::all(glm::epsilonEqual(expectedPoints[i], collision->contacts[j].contactPoint, detector.tolerance)))
+					found = true;
+			}
+			REQUIRE(found == true);
+		}
+	}
+	SECTION("Collider 7/1 - big face/small face")
+	{
+		std::vector<glm::vec3> expectedPoints;
+		expectedPoints.push_back(glm::vec3(0.f, 1.5f, 1.95f));
+		expectedPoints.push_back(glm::vec3(0.f, 1.f, 1.95f));
+		expectedPoints.push_back(glm::vec3(2.f, 1.f, 1.95f));
+		expectedPoints.push_back(glm::vec3(2.f, 1.5f, 1.95f));
+		std::shared_ptr<Collision> collision = detector.Collide(collider7, collider1);
+		REQUIRE(collision != nullptr);
+		REQUIRE(collision->contacts.size() == 4);
+
+		for (int i = 0; i < expectedPoints.size(); i++)
+		{
+			bool found = false;
+			for (int j = 0; j < collision->contacts.size(); j++)
+			{
+				if (glm::all(glm::epsilonEqual(expectedPoints[i], collision->contacts[j].contactPoint, detector.tolerance)))
+					found = true;
+			}
+			REQUIRE(found == true);
+		}
+	}
 }


### PR DESCRIPTION
Problem
=======

The current implementation of the clipping algorithm does not produce contact points when the contact points are not part of the collider. E.g. two slim long planks collide in the middle.

----------------------------------------------------------------------------------------------------------------------

Solution
=======

The implementation should 

1. Get the min penetration data as usual
2. Get the incident face - the most anti-parallel face (from the second collider) to the reference face (the face that has the SAT axis part of the first collider)
3. Using the reference face and the points on it create 4 (possibly more) adjacent faces
4. Use the faces created in step 3 to clip the incident face using the Sutherland-Hodgman algorithm
5. Clip the resulting points against the reference face and return.

Links used : 

1. https://pybullet.org/Bullet/phpBB3/viewtopic.php?f=4&t=10945&p=36680&hilit=SAT+clipping#p36680

2. https://www.gamedev.net/forums/topic/667499-3d-sat-problem/#entry5224015

----------------------------------------------------------------------------------------------------------------------